### PR TITLE
Large requests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: StreamCatTools
 Type: Package
 Title: Tools to Work with the StreamCat API Within R and Access the Full Suite of StreamCat and LakeCat Metrics
-Version: 0.5.0
+Version: 0.6.0
 Authors@R: c(person(given = "Marc", 
                     family = "Weber", 
                     role = c("aut", "cre"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# StreamCatTools 0.6.0
+
 # StreamCatTools 0.5.0
 -   Overhauled `sc_get_data` and `lc_get_data` functions to be able to pull all metrics from StreamCat or LakeCat for an area of interest
 -   Updated `sc_get_data` and `lc_get_data` to be able to pass hundreds of COMIDs at a time as a function parameter and not error out in call to server

--- a/R/lc_get_data.R
+++ b/R/lc_get_data.R
@@ -87,8 +87,12 @@ lc_get_data <- function(comid = NULL,
   # Base API URL.
   req <- httr2::request('https://api.epa.gov/StreamCat/lakes/metrics')
   # Collapse comids into a single string separated by a comma.
-  if (!is.null(comid))
+  if (!is.null(comid)){
     comid <- paste(comid, collapse = ",")
+    if (length(strsplit(comid, ",")[[1]]) > 700){
+      comids_split <- split(COMIDs, ceiling(seq_along(COMIDs)/750))
+    }
+  }
   # Force old and odd naming convention to behave correctly
   if (!is.null(aoi)){
     if (aoi == 'catchment') aoi <- 'cat'
@@ -100,13 +104,8 @@ lc_get_data <- function(comid = NULL,
   if (!is.null(conus) & metric=='all'){
     stop('If you are requesting all metrics please request for regions, states or counties rather than all of conus')
   } 
-  metric = tolower(metric)
-  items = unlist(strsplit(metric,','))
-  items = gsub(" ","",items)
-  items = gsub("\n","",items)
-  params <- sc_get_params(param='metric_names')
-  if (metric != 'all' & !all(items %in% params)){
-    stop("One or more of the provided metric names do not match the expected metric names in StreamCat.  Use sc_get_params(param='name') to list valid metric names for StreamCat")
+  if (metric=='all'){
+    message("Using metric='all' with a large aoi may take a considerable amount of time to return results - request may timeout if multiple AOIs are requested")
   }
   metric = tolower(metric)
   items = unlist(strsplit(metric,','))
@@ -114,25 +113,59 @@ lc_get_data <- function(comid = NULL,
   items = gsub("\n","",items)
   params <- sc_get_params(param='metric_names')
   if (metric != 'all' & !all(items %in% params)){
-    stop("One or more of the provided metric names do not match the expected metric names in StreamCat.  Use sc_get_params(param='name') to list valid metric names for StreamCat")
+    message("One or more of the provided metric names do not match the expected metric names in StreamCat.  Use sc_get_params(param='name') to list valid metric names for StreamCat")
   }
-  df <- req |>
-    httr2::req_method("POST") |>
-    httr2::req_headers(comid=comid,aoi=aoi,name=metric,showareasqkm=showAreaSqKm,
-                       showpctfull=showPctFull,state=state,county=county,region=region,
-                       conus=conus,countOnly=countOnly) |>
-    httr2::req_method("POST") |>
-    httr2::req_throttle(rate = 30 / 60) |> 
-    httr2::req_retry(backoff = ~ 5, max_tries = 3) |>  
-    httr2::req_perform() |> 
-    httr2::resp_body_string() |> 
-    jsonlite::fromJSON()
-  # Return a data frame
-  if (is.null(countOnly)){
-    df <- df$items  |> 
-      dplyr::select(comid, dplyr::everything())
+  metric = tolower(metric)
+  items = unlist(strsplit(metric,','))
+  items = gsub(" ","",items)
+  items = gsub("\n","",items)
+  params <- sc_get_params(param='metric_names')
+  if (metric != 'all' & !all(items %in% params)){
+    message("One or more of the provided metric names do not match the expected metric names in StreamCat.  Use sc_get_params(param='name') to list valid metric names for StreamCat")
+  }
+  if (exists('comid_split')){
+    create_post_request <- function(comids) {
+      df <- req |>
+        httr2::req_method("POST") |>
+        httr2::req_headers(comid=comids,aoi=aoi,name=metric,showareasqkm=showAreaSqKm,
+                           showpctfull=showPctFull,state=state,county=county,region=region,
+                           conus=conus,countOnly=countOnly) |>
+        httr2::req_method("POST") |>
+        httr2::req_throttle(rate = 30 / 60) |> 
+        httr2::req_retry(backoff = ~ 5, max_tries = 3) |>  
+        httr2::req_perform() |> 
+        httr2::resp_body_string() |> 
+        jsonlite::fromJSON() 
+      # Return a data frame
+      if (is.null(countOnly)){
+        df <- df$items  |> 
+          dplyr::select(comid, dplyr::everything())
+        return(df)
+      } else return(df$items)
+    }
+    # Create a list of requests using purrr::map()
+    df <- purrr::map_dfr(comids_split, create_post_request)
     return(df)
-  } else return(df$items)
+    
+  } else {
+    df <- req |>
+      httr2::req_method("POST") |>
+      httr2::req_headers(comid=comid,aoi=aoi,name=metric,showareasqkm=showAreaSqKm,
+                         showpctfull=showPctFull,state=state,county=county,region=region,
+                         conus=conus,countOnly=countOnly) |>
+      httr2::req_method("POST") |>
+      httr2::req_throttle(rate = 30 / 60) |> 
+      httr2::req_retry(backoff = ~ 5, max_tries = 3) |>  
+      httr2::req_perform() |> 
+      httr2::resp_body_string() |> 
+      jsonlite::fromJSON()
+    # Return a data frame
+    if (is.null(countOnly)){
+      df <- df$items  |> 
+        dplyr::select(comid, dplyr::everything())
+      return(df)
+    } else return(df$items)
+  }
 }
 
 #' @title Get NLCD Data

--- a/tests/testthat/test-lc_get_params.R
+++ b/tests/testthat/test-lc_get_params.R
@@ -19,7 +19,7 @@ test_that("lc_get_params for region parameters", {
 test_that("lc_get_params for name parameters", {
   params <- lc_get_params(param='metric_names')
   expect_true(exists("params"))
-  expect_equal(length(params),497)
+  expect_equal(length(params),517)
 })
 
 test_that("lc_get_params for state parameters", {


### PR DESCRIPTION
Fixes #67 and allows passing of 700 or more COMIDs in a request to either `sc_get_data` or `lc_get_data`