### PR TITLE
update docs for sc_get_data and lc_get_data and clarify contributions

### DIFF
--- a/R/lc_get_data.R
+++ b/R/lc_get_data.R
@@ -7,32 +7,37 @@
 #' @author
 #' Marc Weber
 #'
-#' @param metric Name(s) of metrics to query
+#' @param metric Name(s) of metrics to query. Must be character string with comma-delimited list of metrics. \emph{\strong{Not} case-sensitive}.
 #' Syntax: name=<name1>,<name2>
 #'
 #' @param aoi Specify the area of interest described by a metric. By default, all available areas of interest
-#' for a given metric are returned.
+#' for a given metric are returned. \emph{Case-sensitive}.
 #' Syntax: areaOfInterest=<value1>,<value2>
 #' Values: catchment|watershed|
 #'
-#' @param comid Return metric information for specific COMIDs.  Needs to be a character string
-#' and function will convert to this format if needed.
+#' @param comid Return metric information for specific COMIDs. Can be a comma-delimited list, a character vector,
+#' or any object that can be coerced to a comma-delimited list with \code{\link[base]{paste}}. 
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}.
 #' Syntax: comid=<comid1>,<comid2>
 #' 
 #' @param state Return metric information for COMIDs within a specific state. Use a state's abbreviation to
-#' query for a given state.
+#' query for a given state. One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}. 
+#' If specified \emph{and valid}, \code{comid} and \code{county} are ignored. \emph{Case-sensitive}.
 #' Syntax: state=<state1>,<state2>
 #'
 #' @param county Return metric information for COMIDs within a specific county.
 #' Users must use the FIPS code, not county name, as a way to disambiguate counties.
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}. If specified \emph{and valid}, \code{comid} is ignored.
 #' Syntax: county=<county1>,<county1>
 #'
 #' @param region Return metric information for COMIDs within a specified hydroregion.
-#' Hydroregions are specified using full name i.e. 'Region01', 'Region03N', 'Region10L' 
+#' Hydroregions are specified using full name i.e. \code{'Region01'}, \code{'Region03N'}, \code{'Region10L'}
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}.  
+#' If specified \emph{and valid}, \code{comid}, \code{county}, and \code{state} are ignored. \emph{Case-sensitive}.
 #' Syntax: region=<regionid1>,<regionid2>
 #'
-#' @param conus Return all COMIDs in the conterminous United States.
-#' The default value is false.
+#' @param conus Return all COMIDs in the conterminous United States. Character string (\emph{\strong{Not} case-sensitive}) or logical.
+#' The default value is false. If true, \code{comid}, \code{county}, \code{state}, and \code{region} are ignored.
 #' Values: true|false
 #'
 #' @param showAreaSqKm Return the area in square kilometers of a given area of interest.
@@ -46,7 +51,7 @@
 #' count (COLUMNCOUNT) that the server expects to return in a request. The default value is false.
 #' Values: true|false
 #'
-#' @return A tibble of desired StreamCat metrics
+#' @return A tibble of desired StreamCat metrics. If data are missing for all rows of a given metric, then the column for that metric will not exist. If data are missing for only some rows, then they will be specified with NA.
 #'
 #' @examples
 #' \donttest{
@@ -65,6 +70,9 @@
 #' df <- lc_get_data(metric='pcturbmd2006,damdens',
 #' aoi='cat,ws', comid='23783629,23794487,23812618')
 #'
+#' df <- lc_get_data(metric='pcturbmd2006,damdens',
+#' aoi='cat,ws', comid=c('23783629','23794487','23812618'))
+#' 
 #' df <- lc_get_data(metric='pcturbmd2006,damdens',
 #' aoi='cat,ws', comid='23783629,23794487,23812618',
 #' countOnly=TRUE)
@@ -97,7 +105,7 @@ lc_get_data <- function(comid = NULL,
     if (aoi == 'catchment') aoi <- 'cat'
     if (aoi == 'watershed') aoi <- 'ws'
   }
-  if ((is.null(comid) & is.null(state) & is.null(county) & is.null(region) & is.null(conus)) | is.null(metric) |is.null(aoi)){
+  if ((is.null(comid) & is.null(state) & is.null(county) & is.null(region) & is.null(conus)) | is.null(metric) | is.null(aoi)){
     stop('Must provide at a minimum valid comid, metric and aoi to the function')
   }
   if (!is.null(conus) & metric=='all'){

--- a/R/sc_get_data.R
+++ b/R/sc_get_data.R
@@ -7,37 +7,42 @@
 #' @author
 #' Marc Weber
 #'
-#' @param metric Name(s) of metrics to query.  This is a comma delimited list of metrics or
-#' or if metric='all' then all metrics will be queried. 
+#' @param metric Name(s) of metrics to query. Must be character string with comma-delimited list of metrics,
+#' or, if \code{metric='all'} then all metrics will be queried. \emph{\strong{Not} case-sensitive}.
 #' Syntax: name=<name1>,<name2>
 #'
-#' @param aoi Specify the area of interest described by a metric. For riparian area (catrp100 and wsrp100)
-#' if the metric does not have data for the riparian area, no data is returned for that AOI.
-#' Certain metrics have no AOI specified for StreamCat so AOI needs to be left null.  These
-#' metrics are: BankfullDepth, BankfullWidth, CHEM_V2_1, CONN, HABT, HYD, ICI, IWI, TEMP, WettedWidth,
-#' prg_bmmi, and all the mast, msst, mwst metrics
+#' @param aoi Name(s) of areas of interest to query.
+#' If a metric does not have data for a given AOI, no data is returned for that AOI.
+#' Certain metrics that have no AOI specified for StreamCat need the AOI to be specified as \code{'other'}. These
+#' metrics include: BankfullDepth, BankfullWidth, ThalwagDepth (sic), CHEM_V2_1, CONN, HABT, HYD, ICI, IWI, TEMP, WettedWidth,
+#' prg_bmmi, and all the mast, msst, mwst metrics. \emph{Case-sensitive}. 
 #'
 #' Syntax: areaOfInterest=<value1>,<value2>
-#' Values: cat|ws|catrp100|wsrp100
+#' Values: cat|ws|catrp100|wsrp100|other
 #'
-#' @param comid Return metric information for specific COMIDs.  Needs to be a character string
-#' and function will convert to this format if needed.
+#' @param comid Return metric information for specific COMIDs. Can be a comma-delimited list, a character vector,
+#' or any object that can be coerced to a comma-delimited list with \code{\link[base]{paste}}. 
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}.
 #' Syntax: comid=<comid1>,<comid2>
 #'
 #' @param state Return metric information for COMIDs within a specific state. Use a state's abbreviation to
-#' query for a given state.
+#' query for a given state. One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}. 
+#' If specified \emph{and valid}, \code{comid} and \code{county} are ignored. \emph{Case-sensitive}.
 #' Syntax: state=<state1>,<state2>
 #'
 #' @param county Return metric information for COMIDs within a specific county.
 #' Users must use the FIPS code, not county name, as a way to disambiguate counties.
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}. If specified \emph{and valid}, \code{comid} is ignored.
 #' Syntax: county=<county1>,<county1>
 #'
 #' @param region Return metric information for COMIDs within a specified hydroregion.
-#' Hydroregions are specified using full name i.e. 'Region01', 'Region03N', 'Region10L'
+#' Hydroregions are specified using full name i.e. \code{'Region01'}, \code{'Region03N'}, \code{'Region10L'}
+#' One of \code{comid}, \code{county}, \code{state}, or \code{region} is required unless \code{conus='true'}.  
+#' If specified \emph{and valid}, \code{comid}, \code{county}, and \code{state} are ignored. \emph{Case-sensitive}.
 #' Syntax: region=<regionid1>,<regionid2>
 #'
-#' @param conus Return all COMIDs in the conterminous United States.
-#' The default value is false.
+#' @param conus Return all COMIDs in the conterminous United States. Character string (\emph{\strong{Not} case-sensitive}) or logical.
+#' The default value is false. If true, \code{comid}, \code{county}, \code{state}, and \code{region} are ignored.
 #' Values: true|false
 #'
 #' @param showAreaSqKm Return the area in square kilometers of a given area of interest.
@@ -51,7 +56,7 @@
 #' count (COLUMNCOUNT) that the server expects to return in a request. The default value is false.
 #' Values: true|false
 #'
-#' @return A data frame of StreamCat metrics
+#' @return A data frame of StreamCat metrics. If data are missing for all rows of a given metric, then the column for that metric will not exist. If data are missing for only some rows, then they will be specified with NA.
 #'
 #' @examples
 #' \donttest{
@@ -74,7 +79,9 @@
 #' df <- sc_get_data(metric='pcturbmd2006,damdens',
 #' aoi='cat,ws', comid='179,1337,1337420', countOnly='true')
 #'
-#' df <- sc_get_data(metric='thalwagdepth', comid='179,1337,1337420',aoi='other')
+#' df <- sc_get_data(metric='thalwagdepth', comid='179,1337,1337420', aoi='other')
+#' 
+#' df <- sc_get_data(metric='thalwagdepth', comid=c('179','1337','1337420'), aoi='other')
 #' 
 #' df <- sc_get_data(comid='179', aoi='ws', metric='all')
 #'  }
@@ -115,7 +122,7 @@ sc_get_data <- function(comid = NULL,
         aoi <- gsub('riparian_watershed','wsrp100',aoi)
       }
     }
-  if ((is.null(comid) & is.null(state) & is.null(county) & is.null(region) & is.null(conus)) | is.null(metric) |is.null(aoi)){
+  if ((is.null(comid) & is.null(state) & is.null(county) & is.null(region) & is.null(conus)) | is.null(metric) | is.null(aoi)){
     stop('Must provide at a minimum valid comid, metric and aoi to the function')
   }
   if (!is.null(conus) & metric=='all'){

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contributions to development of the package are welcome and encouraged. Please c
 - Contributions should use the standard GitHub [fork - pull-request workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962)
 - We encourage use of the [tidyverse style guide](https://style.tidyverse.org/) for contributions
 - Contributions should ideally be tested using [testthat](https://testthat.r-lib.org/)
-- If you contribute documentation the package uses pkgdown and running `pkgdown::build_site()` will refresh the pkgdown pages for the package
+- If you contribute to documentation, running `devtools::document()` and then `pkgdown::build_site()` will refresh the help docs and pkgdown pages - however, these updates may not be desired in every pull request
 
 ### Python Implementation of StreamCat API
 [PyNHD](https://github.com/hyriver/pynhd), part of the [HyRiver](https://github.com/hyriver) suite of Python packages, also provides access to StreamCat data via the API in Python, along with other NHDPlus value-added attributes for catchments and catchment and network accumulated values for catchments available via [USGS ScienceBase](https://sciencebase.usgs.gov/)


### PR DESCRIPTION
As discussed in [issue 70](https://github.com/USEPA/StreamCatTools/issues/70), I have made some edits to the documentation for sc_get_data to try to make some of the requirements clearer and fix errors. 

1. the statement that 'aoi' should be left 'NULL' was corrected to state that in such cases it should be 'other'
2. case-sensitivity of 'aoi' was noted, as was case-_in_sensitivity of 'metric'
3. specified that, in the case of no relevant data, no data are returned (for all aois, not just riparian)
4. added 'thalwag_depth' to list of metrics that require 'other'. used 'sic' to highlight that this is the required spelling to retrieve the data, although this is perhaps something that should be changed?
5. specified that any vector that can be coerced and pasted will be accepted for 'comid', but tried to make clear that this is not the case for 'metric' or 'aoi' (and added an example)
6.  specified that at least one of comid, county, state, or region is required, but that these are ignored if conus=true
7. tried to make docs for lc_get_data match, though I limited the changes to cases that I tested were actually true
8. added formatting for cleanliness

I also updated the README with a small change to the recommendations for contributors, based on my previous pull request attempt (https://github.com/USEPA/StreamCatTools/pull/72)
