### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "StreamCatTools: An R package for working with StreamCat and LakeCat watershed data in R"
+authors:
+  - family-names: "Weber"
+    given-names: "Marc"
+    orcid: "https://orcid.org/0000-0002-9742-4744"
+  - family-names: "Hill"
+    given-names: "Ryan"
+    orcid: "https://orcid.org/0000-0001-9583-0426"
+  - family-names: "Markley"
+    given-names: "Selia"
+  - family-names: "Hudson"
+    given-names: "Travis"
+  - family-names: "Brookes"
+    given-names: "Allen"
+repository-code: "https://github.com/USEPA/StreamCatTools"
+license: "MIT"
+version: "0.11.0"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `origin/Paper:inst/extdata/JOSS/paper.md`: 5 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

3 author(s) have no ORCID in the paper, so their names were split at the last word. Please correct those if I put the boundary in the wrong place.

`license` is `MIT`, read from the LICENSE file. `version` is `0.11.0`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.